### PR TITLE
Fix libraries install and copy of regulatory.bin

### DIFF
--- a/wifi_txpower_unlocker.sh
+++ b/wifi_txpower_unlocker.sh
@@ -24,7 +24,7 @@ apt-get -y update && apt-get -y upgrade
 
 # Install dependencies
 echo "Installing dependencies..." 1>&2
-apt-get -y install git python m2crypto libgcrypt* libnl* pkg-config build-essential python-dev python-pip curl
+apt-get -y install git python m2crypto pkg-config build-essential python-dev python-pip curl
 pip install setuptools future
 
 echo "Fetching crda and wireless-regdb..." 1>&2
@@ -44,7 +44,10 @@ make -C wireless-regdb/
 
 # Backup old regulatory.bin and copy the newly compiled file into /lib/crda/
 echo "Backing up old regulatory.bin and copying the newly compiled file into /lib/crda/ ..." 1>&2
-cp /lib/crda/regulatory.bin /lib/crda/regulatory.bin.old
+mkdir -p /lib/crda/pubkeys
+if [[ -f /lib/crda/regulatory.bin ]] && [[ ! -f /lib/crda/regulatory.bin.old ]]; then
+	cp /lib/crda/regulatory.bin /lib/crda/regulatory.bin.old
+fi
 cp wireless-regdb/regulatory.bin /lib/crda/
 
 # Newly compiled regulatory.bin was signed by the current user, copy this key into crda


### PR DESCRIPTION
User on arm device Rock64 with linux kernel 4.4.167 (4.4.167-1169-rockchip-ayufan-g3cde5c624c9c).

I had to make these change to `hiruna:update_19042019` to get the script to work:
Removed libraries from apt install command conflicted with installed version and made the script fail
I had no pre-existing folder `/lib/crda` so it had to be created (with `/lib/crda/pubkeys`) before copying files
Added extra test to prevent overwriting backup bin

My apologies if that breaks something on for others, feel free to correct or adapt.
